### PR TITLE
increase request timeouts to 120s

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Currently this supports only RSpec.
 ### Installation
 
 ```rb
-gem "integration-diff-rails", git: "git@github.com:code-mancers/integration-diff-rails"
+gem 'integration-diff'
 ```
 
 ### Configuration

--- a/lib/integration_diff/runner.rb
+++ b/lib/integration_diff/runner.rb
@@ -80,7 +80,7 @@ module IntegrationDiff
     end
 
     def connection
-      @conn ||= Faraday.new(@base_uri) do |f|
+      @conn ||= Faraday.new(@base_uri, request: { timeout: 120, open_timeout: 120 }) do |f|
         f.request :basic_auth, IntegrationDiff.api_key, 'X'
         f.request :multipart
         f.request :url_encoded

--- a/lib/integration_diff/version.rb
+++ b/lib/integration_diff/version.rb
@@ -1,3 +1,3 @@
 module IntegrationDiff
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
scraping pages, and uploading them to our service, which eventually uploads to aws takes lots of time. we should look at delayed inserts